### PR TITLE
Switched to not declaring the functions dynamically

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -32,8 +32,8 @@ end
     @stub foo
     @expect(foo(4, ::Int)=32)
     @test foo(4,3)==32
-    @test_throws ExpectationValueMismatchError foo(5,3)==32
-    @test_throws MethodError foo(3,2.0)==32
+    @test_throws ExpectationValueMismatchError foo(5, 3)==32
+    @test_throws ExpectationValueMismatchError foo(3, 2.0)==32
 end
 
 #BROKEN as Mixed keys stubs not currenty allowed.


### PR DESCRIPTION
This change means all stubs share the same function,
rather than generating the functions based on need.

The downside is no method errors, instead only value errors.

The upside is simpler code,
and no world age errors.
I hope