### PR TITLE
Make Stub a subtype of Function

### DIFF
--- a/src/ExpectationStubs.jl
+++ b/src/ExpectationStubs.jl
@@ -28,7 +28,7 @@ end
 
 ###########################################################
 
-struct Stub{name}
+struct Stub{name} <: Function
     expectations::SortedDict{Any, Any}
     expectation_callcounts::SortedDict{Any, Int}
 end


### PR DESCRIPTION
This seems like it would improve compatibility with various things requiring a function