### PR TITLE
Count uses and shift to Julia0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
+  - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -20,11 +20,12 @@ These stub are ideal for if you already have dependency injection of functions s
 For purposes of this package, a stub and a mock at the same thing.
 
 
-There are 4 key functions (check their docstrings on the REPL).
+There are 5 key functions (check their docstrings on the REPL).
 
  - `@stub foo`: declares a stub called `foo`
  - `@expect foo(::Integer, 8.5)=77`: sets up an expectation that `foo` will be called with an `Integer` and the exact value `8.5`. and if so it is to return `77`
  - `@used  foo(100, ::Real)` checks to see if `foo` was called with the the exact value `100` and something of type `Real`
+ - `@countuse foo(100, ::Real)` as per `@used` except returns the number of times called
  - `all_expectations_used(foo)` checks that every expectation declared on `foo` was used (returns a `Bool`).
 
 ### Example Usage

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,13 +1,23 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
-# - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-# - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86 # 32-bit
+  - x64 # 64-bit
+
+# # Uncomment the following lines to allow failures on nightly julia
+# # (tests will run but not make your overall status red)
+# matrix:
+#   allow_failures:
+#   - julia_version: nightly
 
 branches:
   only:
     - master
+    - /release-.*/
 
 notifications:
   - provider: Email
@@ -16,26 +26,18 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# If there's a newer build queued for the same PR, cancel this one
-  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
-        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
-        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
-        throw "There are newer queued builds for this pull request, failing early." }
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
-
-
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"ExpectationStubs.jl\"); Pkg.build(\"ExpectationStubs.jl\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"ExpectationStubs.jl\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+
+# # Uncomment to support code coverage upload. Should only be enabled for packages
+# # which would have coverage gaps without running on Windows
+# on_success:
+#   - echo "%JL_CODECOV_SCRIPT%"
+#   - C:\julia\bin\julia -e 


### PR DESCRIPTION
This closes #4 , in doing so it moves to julia 0.7 because it is easier to do that there.
Well actually a change pushed to master by mistake closes that. 
I should really revert that and push it back in here.
That is in
https://github.com/oxinabox/ExpectationStubs.jl/commit/7921d28de07e8e110ff74fbc9289e7d052f27283

