### PR TITLE
Make it a warning to overwrite

### DIFF
--- a/src/ExpectationStubs.jl
+++ b/src/ExpectationStubs.jl
@@ -21,11 +21,6 @@ struct ExpectationValueMismatchError <: Exception
 end
 
 
-struct ExpectationAlreadySetError <:Exception
-    name
-    sig
-    argvals
-end
 
 #########################################################
 
@@ -157,7 +152,7 @@ macro expect(defn)
         ###########################################################
         # Check not allready regeistered
         if haskey($(esc(name)).expectations, $(argvals))
-            throw(ExpectationAlreadySetError($(esc(name)), $(esc(sig)), $(argvals)))
+            @warn "Expectation already set" name=$(Meta.quot(name)) argvals=$(argvals) sig=$(esc(sig))
         end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,14 +1,15 @@
 using ExpectationStubs
-using ExpectationStubs: ExpectationValueMismatchError, ExpectationAlreadySetError
+using ExpectationStubs: ExpectationValueMismatchError
 using Test
-
+using Test: @test_logs
 
 @testset "basic stubbing" begin
     @stub foo
     @expect(foo(::Any)=32)
     @test foo(3)==32
     @test foo(4)==32
-    @test_throws ExpectationAlreadySetError @expect(foo(::Any)=34)
+
+    @test_logs (:warn, "Expectation already set") @expect(foo(::Any)=34)
 end
 
 @testset "multitype stubbing" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,6 +10,7 @@ using Test: @test_logs
     @test foo(4)==32
 
     @test_logs (:warn, "Expectation already set") @expect(foo(::Any)=34)
+    @test foo(5)==34
 end
 
 @testset "multitype stubbing" begin


### PR DESCRIPTION
Given over writing a function in julia is a warning it seems fine if this is too